### PR TITLE
Direct Lambda Success and Error Message

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -16,11 +16,11 @@ $(function(){
             },
             success: function(data) {
                 console.log(data);
-                $('#status').text('Mail sent!').show();
+                $('#status').text(data).show();
                 $('#submit').removeProp('disabled');
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                $('#status').text('Mail sending Failed').show();
+                $('#status').text('Mail sending Failed. Error: ' + jqXHR.status).show();
                 $('#submit').removeProp('disabled');
             }
         });


### PR DESCRIPTION
I think it is nicer if we let the Lambda instance control the success message as well as the error message - this also allows us to use the form to reveal hidden data, such as a download url after signup.